### PR TITLE
Add basic Leaflet hunting map

### DIFF
--- a/gebieden.geojson
+++ b/gebieden.geojson
@@ -1,0 +1,37 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {"name": "Voederzone", "type": "voederzone"},
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[[8.055,51.398],[8.058,51.398],[8.058,51.396],[8.055,51.396],[8.055,51.398]]]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {"name": "Wildakker", "type": "wildakker"},
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[[8.060,51.401],[8.065,51.401],[8.065,51.399],[8.060,51.399],[8.060,51.401]]]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {"name": "Bos", "type": "bos"},
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[[8.060,51.395],[8.070,51.395],[8.070,51.392],[8.060,51.392],[8.060,51.395]]]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {"name": "Jachtgebied", "type": "grens"},
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[[8.050,51.402],[8.075,51.402],[8.075,51.390],[8.050,51.390],[8.050,51.402]]]
+      }
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Jachthutten Kaart</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-o88AwfAjpCLH6GCPNtE9Sc/cn68LNkfVfx2Gto0a0wY=" crossorigin=""/>
+    <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+    <div id="map"></div>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-VLqxL3SLRkdIOtqEsl40LFflKQagA5so9tzWji+5O1U=" crossorigin=""></script>
+    <script src="map.js"></script>
+</body>
+</html>

--- a/map.js
+++ b/map.js
@@ -1,0 +1,116 @@
+const startCoords = [51.395, 8.06];
+const startZoom = 13;
+const markers = [];
+
+const map = L.map('map', {
+    zoomControl: false,
+    doubleClickZoom: false,
+    scrollWheelZoom: false,
+    boxZoom: false,
+    touchZoom: false,
+    minZoom: startZoom,
+    maxZoom: startZoom
+}).setView(startCoords, startZoom);
+
+L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+    attribution: '&copy; <a href="https://carto.com/attributions">CARTO</a>'
+}).addTo(map);
+
+// Limit map panning to a fixed boundary
+const bounds = L.latLngBounds([
+    [51.390, 8.050],
+    [51.402, 8.075]
+]);
+map.setMaxBounds(bounds);
+map.on('drag', function() {
+    map.panInsideBounds(bounds, { animate: false });
+});
+
+function saveMarkers() {
+    localStorage.setItem('hutjes', JSON.stringify(markers));
+}
+
+function loadMarkers() {
+    const data = localStorage.getItem('hutjes');
+    if (!data) return;
+    JSON.parse(data).forEach(m => {
+        const marker = L.marker(m.latlng).addTo(map)
+            .bindTooltip(m.name + ' ' + m.number, { permanent: true, direction: 'top' });
+        marker.description = m.desc;
+        markers.push(m);
+    });
+}
+
+map.on('click', function(e) {
+    const name = prompt('Naam van de hut?');
+    if (!name) return;
+    const number = prompt('Nummer?');
+    if (number === null) return;
+    const desc = prompt('Korte beschrijving?') || '';
+
+    const marker = L.marker(e.latlng).addTo(map)
+        .bindTooltip(name + ' ' + number, { permanent: true, direction: 'top' });
+    marker.description = desc;
+    markers.push({ name, number, desc, latlng: e.latlng });
+    saveMarkers();
+});
+
+function zoneStyle(feature) {
+    switch (feature.properties.type) {
+        case 'voederzone':
+            return { color: 'orange', fillColor: 'orange', fillOpacity: 0.5 };
+        case 'wildakker':
+            return { color: 'purple', fillColor: 'purple', fillOpacity: 0.5 };
+        case 'bos':
+            return { color: 'green', fillColor: 'green', fillOpacity: 0.5 };
+        case 'grens':
+            return { color: 'red', fillOpacity: 0, dashArray: '5,5' };
+    }
+}
+
+fetch('gebieden.geojson')
+    .then(resp => resp.json())
+    .then(data => {
+        L.geoJSON(data, {
+            style: zoneStyle,
+            onEachFeature: function(feature, layer) {
+                layer.bindTooltip(feature.properties.name || feature.properties.type);
+            }
+        }).addTo(map);
+    })
+    .catch(err => console.error('GeoJSON laden mislukt', err));
+
+// Legend
+const legend = L.control({ position: 'bottomright' });
+legend.onAdd = function() {
+    const div = L.DomUtil.create('div', 'legend');
+    div.innerHTML =
+        '<i style="background:orange"></i>Voederzone<br>' +
+        '<i style="background:purple"></i>Wildakker<br>' +
+        '<i style="background:green"></i>Bos<br>' +
+        '<i style="background:red"></i>Gebiedgrens';
+    return div;
+};
+legend.addTo(map);
+
+// Locate button
+const locate = L.control({ position: 'topleft' });
+locate.onAdd = function() {
+    const btn = L.DomUtil.create('button', 'locate-btn');
+    btn.innerHTML = 'Locatie';
+    L.DomEvent.on(btn, 'click', function(e) {
+        L.DomEvent.stopPropagation(e);
+        map.locate({ setView: true, maxZoom: startZoom });
+    });
+    return btn;
+};
+locate.addTo(map);
+
+map.on('locationfound', function(e) {
+    if (map._locationMarker) {
+        map.removeLayer(map._locationMarker);
+    }
+    map._locationMarker = L.marker(e.latlng).addTo(map);
+});
+
+loadMarkers();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,33 @@
+html, body {
+    height: 100%;
+    margin: 0;
+}
+#map {
+    width: 100%;
+    height: 100vh;
+}
+
+.leaflet-container {
+    touch-action: none; /* disable pinch zoom */
+}
+
+.legend {
+    background: white;
+    padding: 6px 8px;
+    font: 14px/16px Arial, Helvetica, sans-serif;
+    box-shadow: 0 0 15px rgba(0,0,0,0.2);
+    border-radius: 5px;
+}
+.legend i {
+    width: 18px;
+    height: 18px;
+    float: left;
+    margin-right: 8px;
+    opacity: 0.7;
+}
+.locate-btn {
+    background: white;
+    padding: 6px;
+    border: none;
+    cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- create fullscreen index page
- add mobile-friendly styles
- implement Leaflet map logic with marker prompts and zone layers
- supply example GeoJSON polygons

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846b2a9cfdc83309a426cc9b6841d5c