### PR TITLE
Add editable polygon drawing

### DIFF
--- a/gebieden.geojson
+++ b/gebieden.geojson
@@ -1,0 +1,37 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {"name": "Voederzone", "type": "voederzone"},
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[[8.055,51.398],[8.058,51.398],[8.058,51.396],[8.055,51.396],[8.055,51.398]]]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {"name": "Wildakker", "type": "wildakker"},
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[[8.060,51.401],[8.065,51.401],[8.065,51.399],[8.060,51.399],[8.060,51.401]]]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {"name": "Bos", "type": "bos"},
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[[8.060,51.395],[8.070,51.395],[8.070,51.392],[8.060,51.392],[8.060,51.395]]]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {"name": "Jachtgebied", "type": "grens"},
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[[8.050,51.402],[8.075,51.402],[8.075,51.390],[8.050,51.390],[8.050,51.402]]]
+      }
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Jachthutten Kaart</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-o88AwfAjpCLH6GCPNtE9Sc/cn68LNkfVfx2Gto0a0wY=" crossorigin=""/>
+    <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+    <div id="map"></div>
+    <div id="control-panel">
+        <button id="add-zone-btn">Voeg zone toe</button>
+        <div id="zone-options" class="hidden">
+            <button data-type="bos">Bos</button>
+            <button data-type="wildakker">Wildakker</button>
+            <button data-type="voederplek">Voederplek</button>
+        </div>
+        <button id="confirm-zone" class="hidden">Bevestigen</button>
+        <button id="delete-zone" class="hidden">Verwijderen</button>
+    </div>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-VLqxL3SLRkdIOtqEsl40LFflKQagA5so9tzWji+5O1U=" crossorigin=""></script>
+    <script src="map.js"></script>
+</body>
+</html>

--- a/map.js
+++ b/map.js
@@ -1,0 +1,231 @@
+const startCoords = [51.395, 8.06];
+const startZoom = 13;
+const markers = [];
+const zones = [];
+let drawing = false;
+let drawingType = null;
+let drawingPoints = [];
+let tempMarkers = [];
+let tempLine = null;
+let selectedZone = null;
+let editHandles = [];
+let zoneId = 1;
+
+const addBtn = document.getElementById('add-zone-btn');
+const options = document.getElementById('zone-options');
+const confirmBtn = document.getElementById('confirm-zone');
+const deleteBtn = document.getElementById('delete-zone');
+
+const map = L.map('map', {
+    zoomControl: false,
+    doubleClickZoom: false,
+    scrollWheelZoom: false,
+    boxZoom: false,
+    touchZoom: false,
+    minZoom: startZoom,
+    maxZoom: startZoom
+}).setView(startCoords, startZoom);
+
+L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+    attribution: '&copy; <a href="https://carto.com/attributions">CARTO</a>'
+}).addTo(map);
+
+// Limit map panning to a fixed boundary
+const bounds = L.latLngBounds([
+    [51.390, 8.050],
+    [51.402, 8.075]
+]);
+map.setMaxBounds(bounds);
+map.on('drag', function() {
+    map.panInsideBounds(bounds, { animate: false });
+});
+
+function saveMarkers() {
+    localStorage.setItem('hutjes', JSON.stringify(markers));
+}
+
+function loadMarkers() {
+    const data = localStorage.getItem('hutjes');
+    if (!data) return;
+    JSON.parse(data).forEach(m => {
+        const marker = L.marker(m.latlng).addTo(map)
+            .bindTooltip(m.name + ' ' + m.number, { permanent: true, direction: 'top' });
+        marker.description = m.desc;
+        marker.on('click', function(ev) {
+            L.popup().setLatLng(ev.latlng)
+                .setContent('<strong>' + m.name + ' ' + m.number + '</strong><br>' + m.desc)
+                .openOn(map);
+        });
+        markers.push(m);
+    });
+}
+
+map.on('click', function(e) {
+    if (drawing) {
+        addPoint(e.latlng);
+        return;
+    }
+    if (selectedZone) deselectZone();
+
+    const name = prompt('Naam van de hut?');
+    if (!name) return;
+    const number = prompt('Nummer?');
+    if (number === null) return;
+    const desc = prompt('Korte beschrijving?') || '';
+
+    const marker = L.marker(e.latlng).addTo(map)
+        .bindTooltip(name + ' ' + number, { permanent: true, direction: 'top' });
+    marker.description = desc;
+    marker.on('click', function(ev) {
+        L.popup().setLatLng(ev.latlng)
+            .setContent('<strong>' + name + ' ' + number + '</strong><br>' + desc)
+            .openOn(map);
+    });
+    markers.push({ name, number, desc, latlng: e.latlng });
+    saveMarkers();
+});
+
+function zoneStyle(obj) {
+    const type = obj.type || (obj.properties && obj.properties.type);
+    switch (type) {
+        case 'voederplek':
+        case 'voederzone':
+            return { color: 'sienna', fillColor: 'sienna', fillOpacity: 0.5 };
+        case 'wildakker':
+            return { color: 'yellow', fillColor: 'yellow', fillOpacity: 0.5 };
+        case 'bos':
+            return { color: 'green', fillColor: 'green', fillOpacity: 0.5 };
+        case 'grens':
+            return { color: 'red', fillOpacity: 0, dashArray: '5,5' };
+    }
+}
+
+fetch('gebieden.geojson')
+    .then(resp => resp.json())
+    .then(data => {
+        data.features.forEach(f => {
+            const coords = f.geometry.coordinates[0].map(c => [c[1], c[0]]);
+            createZone(f.properties.type, coords);
+        });
+    })
+    .catch(err => console.error('GeoJSON laden mislukt', err));
+
+// Legend
+const legend = L.control({ position: 'bottomright' });
+legend.onAdd = function() {
+    const div = L.DomUtil.create('div', 'legend');
+    div.innerHTML =
+        '<i style="background:sienna"></i>Voederplek<br>' +
+        '<i style="background:yellow"></i>Wildakker<br>' +
+        '<i style="background:green"></i>Bos<br>' +
+        '<i style="background:red"></i>Gebiedgrens';
+    return div;
+};
+legend.addTo(map);
+
+// Locate button
+const locate = L.control({ position: 'topleft' });
+locate.onAdd = function() {
+    const btn = L.DomUtil.create('button', 'locate-btn');
+    btn.innerHTML = 'Locatie';
+    L.DomEvent.on(btn, 'click', function(e) {
+        L.DomEvent.stopPropagation(e);
+        map.locate({ setView: true, maxZoom: startZoom });
+    });
+    return btn;
+};
+locate.addTo(map);
+
+map.on('locationfound', function(e) {
+    if (map._locationMarker) {
+        map.removeLayer(map._locationMarker);
+    }
+    map._locationMarker = L.marker(e.latlng).addTo(map);
+});
+
+loadMarkers();
+
+addBtn.addEventListener('click', () => {
+    options.classList.toggle('hidden');
+});
+
+options.addEventListener('click', e => {
+    if (e.target.tagName !== 'BUTTON') return;
+    drawing = true;
+    drawingType = e.target.dataset.type;
+    options.classList.add('hidden');
+    clearDrawing();
+});
+
+confirmBtn.addEventListener('click', () => {
+    if (drawingPoints.length < 3) return;
+    createZone(drawingType, drawingPoints);
+    clearDrawing();
+    drawing = false;
+    confirmBtn.classList.add('hidden');
+});
+
+deleteBtn.addEventListener('click', () => {
+    if (!selectedZone) return;
+    map.removeLayer(selectedZone.polygon);
+    zones.splice(zones.indexOf(selectedZone), 1);
+    deselectZone();
+});
+
+function addPoint(latlng) {
+    const m = L.circleMarker(latlng, { radius: 4 }).addTo(map);
+    tempMarkers.push(m);
+    drawingPoints.push(latlng);
+    if (!tempLine) {
+        tempLine = L.polyline(drawingPoints, { dashArray: '4,4' }).addTo(map);
+    } else {
+        tempLine.setLatLngs(drawingPoints);
+    }
+    if (drawingPoints.length >= 3) confirmBtn.classList.remove('hidden');
+}
+
+function clearDrawing() {
+    tempMarkers.forEach(m => map.removeLayer(m));
+    tempMarkers = [];
+    if (tempLine) { map.removeLayer(tempLine); tempLine = null; }
+    drawingPoints = [];
+}
+
+function createZone(type, latlngs) {
+    const poly = L.polygon(latlngs, zoneStyle({type})).addTo(map);
+    const zone = { id: zoneId++, type, polygon: poly, latlngs: latlngs.slice() };
+    poly.on('click', function(e) {
+        L.DomEvent.stopPropagation(e);
+        selectZone(zone);
+        poly.openPopup(e.latlng);
+    });
+    poly.bindPopup('Type: ' + type + '<br>ID: ' + zone.id);
+    zones.push(zone);
+    return zone;
+}
+
+function selectZone(zone) {
+    deselectZone();
+    selectedZone = zone;
+    deleteBtn.classList.remove('hidden');
+    zone.latlngs = zone.polygon.getLatLngs()[0];
+    zone.latlngs.forEach((latlng, idx) => {
+        const handle = L.marker(latlng, {
+            draggable: true,
+            icon: L.divIcon({ className: 'vertex-handle' })
+        }).addTo(map);
+        handle.on('drag', ev => {
+            zone.latlngs[idx] = ev.target.getLatLng();
+            zone.polygon.setLatLngs(zone.latlngs);
+        });
+        editHandles.push(handle);
+    });
+}
+
+function deselectZone() {
+    if (!selectedZone) return;
+    editHandles.forEach(h => map.removeLayer(h));
+    editHandles = [];
+    deleteBtn.classList.add('hidden');
+    selectedZone = null;
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,60 @@
+html, body {
+    height: 100%;
+    margin: 0;
+}
+#map {
+    width: 100%;
+    height: 100vh;
+}
+
+.leaflet-container {
+    touch-action: none; /* disable pinch zoom */
+}
+
+.legend {
+    background: white;
+    padding: 6px 8px;
+    font: 14px/16px Arial, Helvetica, sans-serif;
+    box-shadow: 0 0 15px rgba(0,0,0,0.2);
+    border-radius: 5px;
+}
+.legend i {
+    width: 18px;
+    height: 18px;
+    float: left;
+    margin-right: 8px;
+    opacity: 0.7;
+}
+.locate-btn {
+    background: white;
+    padding: 6px;
+    border: none;
+    cursor: pointer;
+}
+
+#control-panel {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 1000;
+    background: rgba(255,255,255,0.9);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    padding: 8px;
+}
+#zone-options button {
+    margin-right: 4px;
+}
+.hidden {
+    display: none;
+}
+
+.vertex-handle {
+    width: 12px;
+    height: 12px;
+    background: blue;
+    border: 2px solid white;
+    border-radius: 50%;
+}


### PR DESCRIPTION
## Summary
- add mobile control panel for drawing zones
- implement interactive polygon creation and editing
- store zones in memory and allow deletion
- show popups for polygons and markers

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846b2a9cfdc83309a426cc9b6841d5c